### PR TITLE
Update WoodWorking.md

### DIFF
--- a/Specs/WoodWorking.md
+++ b/Specs/WoodWorking.md
@@ -122,14 +122,14 @@ This is the current mapping:
 
 #### Throughfeed
 
-- SawingMachine --> Throughfeed
-- ProfilingMachine --> Throughfeed
-- EdgebandingMachine --> Throughfeed
-- BoringMachine --> Throughfeed
-- SandingMachine --> Throughfeed
-- HandlingMachine --> Throughfeed
+- ProfilingMachine
+- EdgebandingMachine
+- BoringMachine
+- SandingMachine
+- HandlingMachine
 
 #### Stationary
 
 - MachiningCenter
 - Press
+- SawingMachine


### PR DESCRIPTION
SawingMachine changed from Device Classes "Throughfeed" to "Stationary" as feedspeed makes no sense to be displayed.